### PR TITLE
Updated a typo error on line 196.

### DIFF
--- a/docs/source/getting-started/command-line-interface/db.rst
+++ b/docs/source/getting-started/command-line-interface/db.rst
@@ -193,4 +193,4 @@ Example usage\:
   $ augur db create-schema
 
 .. note::
-  If this runs sucessfully, you should see a bunch of schema creation commands fly by pretty fast. If everything worked you should see: ``update "augur_operations"."augur_settings" set value = xx where setting = 'augur_data_version';`` at the end.
+  If this runs successfully, you should see a bunch of schema creation commands fly by pretty fast. If everything worked you should see: ``update "augur_operations"."augur_settings" set value = xx where setting = 'augur_data_version';`` at the end.


### PR DESCRIPTION
It read "If this runs sucessfully, you should see a bunch of schema creation commands fly by pretty fast. If everything worked you should see: ``update ", 
it now reads "If this runs successfully, you should see a bunch of schema creation commands fly by pretty fast. If everything worked you should see: ``update "


